### PR TITLE
send line items in request body as part of coupon validation

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -242,12 +242,13 @@ define(function(require) {
     // Coupon adds a discount
     updateDiscount: function() {
       var code = this._getCouponCode();
+      var lineItems = this._getLineItems();
       var priceSelector = '.Celery-OrderSummary-price--coupon';
       var operatorSelector = '.Celery-OrderSummary-operator.coupon';
       var lineSelector = '.Celery-OrderSummary-line.coupon';
       var groupSelector = lineSelector + ', ' + operatorSelector;
 
-      coupon.validate(code, $.proxy(function(valid) {
+      coupon.validate(code, lineItems, $.proxy(function(valid) {
         var discount;
 
         this.updateTaxes();
@@ -323,13 +324,7 @@ define(function(require) {
         }
       }
 
-      // Line Item
-      var lineItem = {
-        product_id: shop.data.product._id,
-        quantity: this._getQuantity()
-      };
-
-      order.line_items.push(lineItem);
+      order.line_items = this._getLineItems();
 
       return order;
     },
@@ -372,6 +367,17 @@ define(function(require) {
 
     _getPrice: function() {
       return shop.data.product && shop.data.product.price;
+    },
+
+    _getLineItems: function() {
+      var lineItem = {
+        product_id: shop.data.product._id,
+        // variant_id: celeryClient.config.variantId, // uncomment if variants are used
+        price: this._getPrice(),
+        quantity: this._getQuantity()
+      };
+
+      return [lineItem];
     },
 
     _getLineItemsTotal: function() {

--- a/src/js/coupon.js
+++ b/src/js/coupon.js
@@ -10,22 +10,12 @@ define(function(require) {
 
       code = code.toLowerCase();
 
-      // Cache hit
-      if (this.data[code] !== undefined) {
-        var coupon = this.data[code];
-
-        // Invalid
-        if (coupon === false) {
-          return cb(false);
-        }
-
-        // Valid
-        return cb(true);
-      }
-
       // Code not found, fetch and try again
       this.fetch(code, lineItems, function(err, data) {
-        this.validate(code, lineItems, cb);
+        if (this.data[code]) {
+          return cb(true);
+        }
+        return cb(false);
       });
     },
 

--- a/src/js/coupon.js
+++ b/src/js/coupon.js
@@ -3,7 +3,7 @@ define(function(require) {
 
   return {
     // Coupon adds a discount
-    validate: function(code, cb) {
+    validate: function(code, lineItems, cb) {
       if (!code) {
         return cb(true);
       }
@@ -24,14 +24,15 @@ define(function(require) {
       }
 
       // Code not found, fetch and try again
-      this.fetch(code, function(err, data) {
-        this.validate(code, cb);
+      this.fetch(code, lineItems, function(err, data) {
+        this.validate(code, lineItems, cb);
       });
     },
 
-    fetch: function(code, cb) {
+    fetch: function(code, lineItems, cb) {
       return celeryClient.fetchCoupon({
-        code: code
+        code: code,
+        line_items: lineItems,
       }, $.proxy(function(err, data) {
         // Cache result
         if (err || !data || !data.data || data.data.code === undefined) {


### PR DESCRIPTION
This allows for product-specific coupons (i.e., take $100 off only if buyer purchases X product, but not if they purchase Y product).